### PR TITLE
fix/update-vulnerable-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "test": "grunt"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": "^1.0.4",
     "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-jshint": "~0.11.0",
-    "grunt-jscs": "^1.5.0"
+    "grunt-contrib-jshint": "^2.1.0",
+    "grunt-jscs": "^3.0.1"
   },
   "keywords": [
     "gruntplugin",
@@ -40,6 +40,6 @@
   ],
   "dependencies": {
     "ini": "~1.3.0",
-    "lodash": "~4.17.10"
+    "lodash": "~4.17.15"
   }
 }

--- a/tasks/env.js
+++ b/tasks/env.js
@@ -48,11 +48,11 @@ module.exports = function(grunt) {
   function processDirectives(options) {
 
     var dispatch = {
-      add : add,
-      replace : replace,
-      unshift : arrayLike.bind({}, 'unshift'),
-      push : arrayLike.bind({}, 'push'),
-      concat : arrayLike.bind({}, 'push')
+      add: add,
+      replace: replace,
+      unshift: arrayLike.bind({}, 'unshift'),
+      push: arrayLike.bind({}, 'push'),
+      concat: arrayLike.bind({}, 'push')
     };
 
     _.forEach(options, function(optionData, option) {


### PR DESCRIPTION
fixed all the vulnerabilities expect the ones posed by the package [grunt-jscs](https://github.com/jscs-dev/grunt-jscs) which hasn't been updated since 2016